### PR TITLE
add split-lines that doesn't ignore empty lines

### DIFF
--- a/src-cljs/atom_parinfer/core.cljs
+++ b/src-cljs/atom_parinfer/core.cljs
@@ -2,12 +2,18 @@
   (:require
     [atom-parinfer.util :refer [always-nil by-id js-log lines-diff log
                                 log-atom-changes one? qs remove-el!]]
-    [clojure.string :refer [join split-lines trim]]
+    [clojure.string :refer [join trim]]
     [clojure.walk :refer [keywordize-keys]]
     [goog.string :as gstring]
     [lowline.functions :refer [debounce]]))
 
 (declare load-file-extensions! toggle-mode!)
+
+(defn split-lines
+  "Same as clojure.string/split-lines, except it doesn't remove empty lines at
+  the end of the text."
+  [text]
+  (vec (.split text #"\r?\n")))
 
 ;;------------------------------------------------------------------------------
 ;; JS Requires


### PR DESCRIPTION
The index-out-of-bounds errors from #37, #38, #39, #40, #41, #42 are probably related to the cursor being on an empty line at the end of the file.

Clojure's `split-lines` functions removes these empty lines for some reason:

```clj
(clojure.string/split-lines "\n\nhello\n\nworld\n\n\n\n")
;; => ["" "" "hello" "" "world"]
```

Added a new `split-lines` function that just wraps JavaScript's `string.split`, which does not ignore these lines.