### PR TITLE
update to parinfer 1.6.1, correct cursor position

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "dependencies": {
     "fs-plus": "2.8.1",
-    "parinfer": "1.5.3"
+    "parinfer": "1.6.1"
   }
 }

--- a/src-cljs/atom_parinfer/core.cljs
+++ b/src-cljs/atom_parinfer/core.cljs
@@ -258,16 +258,23 @@
         js-result (if (= mode :paren-mode)
                     (parinfer.parenMode text-to-infer js-opts)
                     (parinfer.indentMode text-to-infer js-opts))
+        new-cursor (js-obj
+                     "row" (aget cursor "row")
+                     "column" (aget js-result "cursorX"))
         parinfer-success? (true? (aget js-result "success"))
-        inferred-text (if parinfer-success? (aget js-result "text") false)]
+        inferred-text (if parinfer-success? (aget js-result "text") false)
+        selection? (not (.isEmpty (aget selections 0)))]
+
     ;; update the text buffer
     (when (and (string? inferred-text)
                (not= inferred-text text-to-infer))
       (.setTextInBufferRange editor (array (array start-row 0) (array end-row 0))
                                     inferred-text
                                     (js-obj "undo" "skip"))
-      (.setCursorBufferPosition editor cursor)
-      (.setSelectedBufferRanges editor selections))
+      (if selection?
+        (.setSelectedBufferRanges editor selections)
+        (.setCursorBufferPosition editor new-cursor)))
+
     ;; update the status bar
     (if (and (= mode :paren-mode)
              (not parinfer-success?))


### PR DESCRIPTION
parinfer now returns a cursor position.  tested this myself, works good

One change to note: since setting the selection will override the cursor, I only update the cursor if no selection is made.  This seems to be okay for cases where updating the cursor matters.