### PR TITLE
Dim paren trail

### DIFF
--- a/grammars/README.md
+++ b/grammars/README.md
@@ -1,0 +1,112 @@
+# Clojure Grammar for Parinfer
+
+This is a modification to [language-clojure 0.19.1] which adds the
+`.paren-trail` class to Paren Trail tokens.
+
+[language-clojure 0.19.1]:https://github.com/atom/language-clojure/blob/master/grammars/clojure.cson
+
+Gif showing Before and After `.paren-trail { opacity: 0.3; }`:
+
+![gif](http://i.imgur.com/gLlW7fB.gif)
+
+## How are Paren Trails detected?
+
+The original Clojure grammar has regex patterns for detecting where the
+collection delimiters begin and end.  For example, here's the original regex
+pattern for detecting the end of a map `}`.
+
+```coffee
+'end': '(\\})'
+'endCaptures':
+  '1':
+    'name': 'punctuation.section.map.end.clojure'
+```
+
+Since the `end` regex can have capture groups, `endCaptures` allows you to
+apply a CSS class to each group by index.
+
+We want to create a regex that will detect if the `}` is in the Paren Trail,
+then apply the `.paren-trail` CSS class.  We perform the following
+modification, with our regex exploded below in detail:
+
+```coffee
+'end': '(\\}(?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\})'
+
+#       regex exploded...
+#       ---------------------------------------
+#       (                               )|(   )  <----- result is 1 of 2 possible capture groups
+#        \\}                               \\}   <----- both start with a `}`
+#           (?=                        )         <----- 1st capture group has a lookahead (which is not captured)
+#              [            ]*                   <----- zero or more characters that are...
+#               \\}\\]\\)\\s                     <----- ... `}` `]` `)` or whitespace
+#                             (?:     )          <----- end with a non-captured group...
+#                                ;|\\n           <----- ... a semicolon or newline
+#       ---------------------------------------
+
+'endCaptures':
+  '1':
+    'name': 'punctuation.section.map.end.clojure.paren-trail'
+  '2':
+    'name': 'punctuation.section.map.end.clojure'
+```
+
+  We apply these modifications for each of the following patterns:
+
+```
+  {} `map`
+ ^{} `meta.metadata.map.clojure`
+ #{} `set`
+  [] `vector`
+```
+
+## Special Case for S-Expressions
+
+To apply modifications to the following patterns, we must do something slightly
+different.
+
+```
+  () `sexp`
+ '() `quoted-sexp`
+ `() `quoted-sexp` (backtick-quoted)
+```
+
+The original grammars for the patterns above will treat `)\n` specially, by
+adding a `after-expression` class to the `\n` token.  See grammar below:
+
+```coffee
+'end': '(\\))(\\n)?'
+'endCaptures':
+  '1':
+    'name': 'punctuation.section.expression.end.clojure'
+  '2':
+    'name': 'meta.after-expression.clojure'
+```
+
+
+```coffee
+'end': '(\\))(\\n)|(\\)(?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\))'
+
+#       regex exploded...
+#       --------------------------------------------------
+#       (   )(   )|(                               )|(   )  <----- high-level capture groups (4)
+#        \\)  \\n                                           <----- 1st and 2nd groups are together
+#                   ...............................         <----- 3rd group same as 1st in previous section
+#                                                     \\)   <----- 4th group
+#       --------------------------------------------------
+
+'endCaptures':
+  '1':
+    'name': 'punctuation.section.expression.end.clojure.paren-trail'
+  '2':
+    'name': 'meta.after-expression.clojure'
+  '3':
+    'name': 'punctuation.section.expression.end.clojure.paren-trail'
+  '4':
+    'name': 'punctuation.section.expression.end.clojure'
+```
+
+## Resources
+
+Atom's Grammar files are the same as TextMate's: <https://manual.macromates.com/en/language_grammars>
+
+

--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -1,6 +1,3 @@
-# Clojure Grammar for Atom
-# (copied from https://github.com/atom/language-clojure/blob/master/grammars/clojure.cson)
-
 'scopeName': 'source.clojure'
 'fileTypes': [
   'boot'
@@ -13,7 +10,7 @@
 ]
 'foldingStartMarker': '\\(\\s*$'
 'foldingStopMarker': '^\\s*\\)'
-'name': 'Clojure'
+'name': 'Clojure (w/ Parinfer)'
 'patterns': [
   {
     'include': '#comment'
@@ -142,9 +139,11 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.map.begin.clojure'
-    'end': '(\\})'
+    'end': '(\\}(?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\})'
     'endCaptures':
       '1':
+        'name': 'punctuation.section.map.end.clojure.paren-trail'
+      '2':
         'name': 'punctuation.section.map.end.clojure'
     'name': 'meta.map.clojure'
     'patterns': [
@@ -159,9 +158,11 @@
         'beginCaptures':
           '1':
             'name': 'punctuation.section.metadata.map.begin.clojure'
-        'end': '(\\})'
+        'end': '(\\}(?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\})'
         'endCaptures':
           '1':
+            'name': 'punctuation.section.metadata.map.end.clojure.paren-trail'
+          '2':
             'name': 'punctuation.section.metadata.map.end.clojure'
         'name': 'meta.metadata.map.clojure'
         'patterns': [
@@ -189,12 +190,16 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.expression.begin.clojure'
-    'end': '(\\))(\\n)?'
+    'end': '(\\))(\\n)|(\\)(?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\))'
     'endCaptures':
       '1':
-        'name': 'punctuation.section.expression.end.clojure'
+        'name': 'punctuation.section.expression.end.clojure.paren-trail'
       '2':
         'name': 'meta.after-expression.clojure'
+      '3':
+        'name': 'punctuation.section.expression.end.clojure.paren-trail'
+      '4':
+        'name': 'punctuation.section.expression.end.clojure'
     'name': 'meta.quoted-expression.clojure'
     'patterns': [
       {
@@ -218,9 +223,11 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.set.begin.clojure'
-    'end': '(\\})'
+    'end': '(\\}(?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\})'
     'endCaptures':
       '1':
+        'name': 'punctuation.section.set.end.clojure.paren-trail'
+      '2':
         'name': 'punctuation.section.set.end.clojure'
     'name': 'meta.set.clojure'
     'patterns': [
@@ -233,12 +240,16 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.expression.begin.clojure'
-    'end': '(\\))(\\n)?'
+    'end': '(\\))(\\n)|(\\)(?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\))'
     'endCaptures':
       '1':
-        'name': 'punctuation.section.expression.end.clojure'
+        'name': 'punctuation.section.expression.end.clojure.paren-trail'
       '2':
         'name': 'meta.after-expression.clojure'
+      '3':
+        'name': 'punctuation.section.expression.end.clojure.paren-trail'
+      '4':
+        'name': 'punctuation.section.expression.end.clojure'
     'name': 'meta.expression.clojure'
     'patterns': [
       {
@@ -338,9 +349,11 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.vector.begin.clojure'
-    'end': '(\\])'
+    'end': '(\\](?=[\\}\\]\\)\\s]*(?:;|\\n)))|(\\])'
     'endCaptures':
       '1':
+        'name': 'punctuation.section.vector.end.clojure.paren-trail'
+      '2':
         'name': 'punctuation.section.vector.end.clojure'
     'name': 'meta.vector.clojure'
     'patterns': [

--- a/grammars/clojure.cson
+++ b/grammars/clojure.cson
@@ -1,0 +1,353 @@
+# Clojure Grammar for Atom
+# (copied from https://github.com/atom/language-clojure/blob/master/grammars/clojure.cson)
+
+'scopeName': 'source.clojure'
+'fileTypes': [
+  'boot'
+  'clj'
+  'cljc'
+  'cljs'
+  'cljx'
+  'clojure'
+  'edn'
+]
+'foldingStartMarker': '\\(\\s*$'
+'foldingStopMarker': '^\\s*\\)'
+'name': 'Clojure'
+'patterns': [
+  {
+    'include': '#comment'
+  }
+  {
+    'include': '#shebang-comment'
+  }
+  {
+    'include': '#quoted-sexp'
+  }
+  {
+    'include': '#sexp'
+  }
+  {
+    'include': '#keyfn'
+  }
+  {
+    'include': '#string'
+  }
+  {
+    'include': '#vector'
+  }
+  {
+    'include': '#set'
+  }
+  {
+    'include': '#map'
+  }
+  {
+    'include': '#regexp'
+  }
+  {
+    'include': '#var'
+  }
+  {
+    'include': '#constants'
+  }
+  {
+    'include': '#dynamic-variables'
+  }
+  {
+    'include': '#metadata'
+  }
+  {
+    'include': '#namespace-symbol'
+  }
+  {
+    'include': '#symbol'
+  }
+  {
+    'include': '#whitespace'
+  }
+]
+'repository':
+  'comment':
+    'captures':
+      '1':
+        'name': 'punctuation.definition.comment.clojure'
+    'match': '(;).*$\\n?'
+    'name': 'comment.line.semicolon.clojure'
+  'constants':
+    'patterns': [
+      {
+        'match': '(nil)(?=(\\s|\\)|\\]|\\}))'
+        'name': 'constant.language.nil.clojure'
+      }
+      {
+        'match': '(true|false)'
+        'name': 'constant.language.boolean.clojure'
+      }
+      {
+        'match': '(-?\\d+/\\d+)'
+        'name': 'constant.numeric.ratio.clojure'
+      }
+      {
+        'match': '(-?\\d+[rR][0-9a-zA-Z]+)'
+        'name': 'constant.numeric.arbitrary-radix.clojure'
+      }
+      {
+        'match': '(-?0[xX][0-9a-fA-F]+)'
+        'name': 'constant.numeric.hexadecimal.clojure'
+      }
+      {
+        'match': '(-?0\\d+)'
+        'name': 'constant.numeric.octal.clojure'
+      }
+      {
+        'match': '(-?\\d+\\.\\d+([eE][+-]?\\d+)?M)'
+        'name': 'constant.numeric.bigdecimal.clojure'
+      }
+      {
+        'match': '(-?\\d+\\.\\d+([eE][+-]?\\d+)?)'
+        'name': 'constant.numeric.double.clojure'
+      }
+      {
+        'match': '(-?\\d+N)'
+        'name': 'constant.numeric.bigint.clojure'
+      }
+      {
+        'match': '(-?\\d+)'
+        'name': 'constant.numeric.long.clojure'
+      }
+      { # separating the pattern for reuse
+        'include': '#keyword'
+      }
+    ]
+  'keyword':
+    'match': '(?<=(\\s|\\(|\\[|\\{)):[a-zA-Z0-9\\#\\.\\-\\_\\:\\+\\=\\>\\<\\/\\!\\?\\*]+(?=(\\s|\\)|\\]|\\}|\\,))'
+    'name': 'constant.keyword.clojure'
+  'keyfn':
+    'patterns': [
+      {
+        'match': '(?<=(\\s|\\(|\\[|\\{))(if(-[-a-z\\?]*)?|when(-[-a-z]*)?|for(-[-a-z]*)?|cond|do|let(-[-a-z\\?]*)?|binding|loop|recur|fn|throw[a-z\\-]*|try|catch|finally|([a-z]*case))(?=(\\s|\\)|\\]|\\}))'
+        'name': 'storage.control.clojure'
+      }
+      {
+        'match': '(?<=(\\s|\\(|\\[|\\{))(declare-?|(in-)?ns|import|use|require|load|compile|(def[a-z\\-]*))(?=(\\s|\\)|\\]|\\}))'
+        'name': 'keyword.control.clojure'
+      }
+    ]
+  'dynamic-variables':
+    'match': '\\*[\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\d]+\\*'
+    'name': 'meta.symbol.dynamic.clojure'
+  'map':
+    'begin': '(\\{)'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.section.map.begin.clojure'
+    'end': '(\\})'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.section.map.end.clojure'
+    'name': 'meta.map.clojure'
+    'patterns': [
+      {
+        'include': '$self'
+      }
+    ]
+  'metadata':
+    'patterns': [
+      {
+        'begin': '(\\^\\{)'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.section.metadata.map.begin.clojure'
+        'end': '(\\})'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.section.metadata.map.end.clojure'
+        'name': 'meta.metadata.map.clojure'
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
+      }
+      {
+        'begin': '(\\^)'
+        'end': '(\\s)'
+        'name': 'meta.metadata.simple.clojure'
+        'patterns': [
+          {
+            'include': '#keyword'
+          }
+          {
+            'include': '$self'
+          }
+        ]
+      }
+    ]
+  'quoted-sexp':
+    'begin': '([\'``]\\()'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.section.expression.begin.clojure'
+    'end': '(\\))(\\n)?'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.section.expression.end.clojure'
+      '2':
+        'name': 'meta.after-expression.clojure'
+    'name': 'meta.quoted-expression.clojure'
+    'patterns': [
+      {
+        'include': '$self'
+      }
+    ]
+  'regexp':
+    'begin': '#\\"'
+    'end': '\\"'
+    'name': 'string.regexp.clojure'
+    'patterns': [
+      {
+        'include': '#regexp_escaped_char'
+      }
+    ]
+  'regexp_escaped_char':
+    'match': '\\\\(\\")'
+    'name': 'string.regexp.clojure'
+  'set':
+    'begin': '(\\#\\{)'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.section.set.begin.clojure'
+    'end': '(\\})'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.section.set.end.clojure'
+    'name': 'meta.set.clojure'
+    'patterns': [
+      {
+        'include': '$self'
+      }
+    ]
+  'sexp':
+    'begin': '(\\()'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.section.expression.begin.clojure'
+    'end': '(\\))(\\n)?'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.section.expression.end.clojure'
+      '2':
+        'name': 'meta.after-expression.clojure'
+    'name': 'meta.expression.clojure'
+    'patterns': [
+      {
+        'begin': '(?<=\\()(ns|def|def-|defn|defn-|defvar|defvar-|defmacro|defmacro-|deftest)\\s+'
+        'beginCaptures':
+          '1':
+            'name': 'keyword.control.clojure'
+        'end': '(?=\\))'
+        'name': 'meta.definition.global.clojure'
+        'patterns': [
+          {
+            # there may be some metadata before an actual definition
+            'include': '#metadata'
+          }
+          { # dynamic variables are rendered diferently
+            'include': '#dynamic-variables'
+          }
+          {
+            # recognizing a symbol as being defined here
+            # copied and pasted from #symbol, screw it
+            'match': '([\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]+)'
+            'name': 'entity.global.clojure'
+          }
+          {
+            'include': '$self'
+          }
+        ]
+      }
+      {
+        'include': '#keyfn'
+      }
+      {
+        'include': '#constants'
+      }
+      {
+        'include': '#vector'
+      }
+      {
+        'match': '(?<=\\()(.+?)(?=\\s|\\))'
+        'captures':
+          '1':
+            'name': 'entity.name.function.clojure'
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
+      }
+      {
+        'include': '$self'
+      }
+    ]
+  'shebang-comment':
+    'captures':
+      '1':
+        'name': 'punctuation.definition.comment.shebang.clojure'
+    'match': '^(\\#!).*$\\n?'
+    'name': 'comment.line.semicolon.clojure'
+  'string':
+    'begin': '(?<!\\\\)(")'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.definition.string.begin.clojure'
+    'end': '(")'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.definition.string.end.clojure'
+    'name': 'string.quoted.double.clojure'
+    'patterns': [
+      {
+        'match': '\\\\.'
+        'name': 'constant.character.escape.clojure'
+      }
+    ]
+  'namespace-symbol':
+    'patterns': [
+      { # copied from #symbol, plus a / at the end. Matches the "app/" part of
+        # "app/*config*"
+        'match': '([\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]+)/'
+        'captures':
+          '1':
+            'name': 'meta.symbol.namespace.clojure'
+      }
+    ]
+  'symbol':
+    'patterns': [
+      {
+        'match': '([\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]+)'
+        'name': 'meta.symbol.clojure'
+      }
+    ]
+  'var':
+    'match': '(?<=(\\s|\\(|\\[|\\{)\\#)\'[a-zA-Z0-9\\.\\-\\_\\:\\+\\=\\>\\<\\/\\!\\?\\*]+(?=(\\s|\\)|\\]|\\}))'
+    'name': 'meta.var.clojure'
+  'vector':
+    'begin': '(\\[)'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.section.vector.begin.clojure'
+    'end': '(\\])'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.section.vector.end.clojure'
+    'name': 'meta.vector.clojure'
+    'patterns': [
+      {
+        'include': '$self'
+      }
+    ]
+  'whitespace':
+    'match': '\\s+$'
+    'name': 'invalid.trailing-whitespace'

--- a/styles/atom-parinfer.less
+++ b/styles/atom-parinfer.less
@@ -16,21 +16,8 @@
   color: @text-color-error;
 }
 
-// NOTE: this is not ready yet, but wanted to save it for future reference
-//       https://github.com/oakmac/atom-parinfer/issues/26
-//
-// @endParenOpacity: 0.5;
-//
-// atom-text-editor::shadow {
-//   span.punctuation.section.map.end.clojure {
-//     opacity: @endParenOpacity;
-//   }
-//
-//   span.punctuation.section.set.end.clojure {
-//     opacity: @endParenOpacity;
-//   }
-//
-//   span.punctuation.section.expression.end.clojure {
-//     opacity: @endParenOpacity;
-//   }
-// }
+atom-text-editor::shadow {
+  span.paren-trail {
+    opacity: 0.5;
+  }
+}


### PR DESCRIPTION
Fixes #26 by adding the modified clojure grammar to this package.  It seems to override the default Clojure grammar, so I named it `Clojure (w/ Parinfer)`, which you can see in the status bar:

<img width="676" alt="screen shot 2016-02-23 at 2 43 42 am" src="https://cloud.githubusercontent.com/assets/116838/13249158/793d0af6-d9d7-11e5-857d-875e2d50d55d.png">

I don't think this will be merged into language-clojure since it introduces long patterns that are specific to parinfer.  I documented the grammar changes to make it clear what has changed and how it works.  If the official clojure grammar is updated in the future, it'll likely be a small change that we can merge easily.