### PR TITLE
Dim paren trails using language-clojure 0.21.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,33 @@ happen in Indent Mode because Parinfer ensures that parens are always balanced.
 Also note that there is a [known bug] with this feature due to the "parent
 expression" hack explained below.
 
+### Dim Trailing Parens
+
+We try to visually communicate which close-parens are inferred by dimming them,
+as per Parinfer's design.
+
+```less
+atom-text-editor::shadow {
+  span.punctuation.section.end.trailing.clojure {
+    opacity: 0.4; // <-- desired opacity of trailing parens
+  }
+}
+```
+
+This is currently only supported for Clojure using
+the [language-clojure] >= 0.21.0. Core packages cannot be upgraded, so you
+may have to use the `apm` command to install it as a user package:
+
+```
+$ apm install language-clojure
+```
+
+Adding this feature to other language packages for Lisp can be done by porting
+the [extra style classes that we added to language-clojure][style-extras].
+
+[language-clojure]:https://github.com/atom/language-clojure
+[style-extras]:https://github.com/atom/language-clojure/pull/37/files
+
 ## Known Limitations
 
 This extension uses a hack for performance reasons that may act oddly in certain

--- a/README.md
+++ b/README.md
@@ -80,12 +80,6 @@ happen in Indent Mode because Parinfer ensures that parens are always balanced.
 Also note that there is a [known bug] with this feature due to the "parent
 expression" hack explained below.
 
-### Future Features
-
-More options and configuration settings are planned for future releases. Browse
-the [issues] for an idea of future features. Create a new issue if you can think
-of a useful feature :)
-
 ## Known Limitations
 
 This extension uses a hack for performance reasons that may act oddly in certain
@@ -104,6 +98,10 @@ Future features include:
 * JSHint-like comments to automatically "turn on" Parinfer for files ([Issue #5](https://github.com/oakmac/atom-parinfer/issues/5))
 * JSHint-like comments to tell Parinfer to ignore sections of your code ([Issue #6](https://github.com/oakmac/atom-parinfer/issues/6))
 * A menu option to run Paren Mode on all files in a directory ([Issue #21](https://github.com/oakmac/atom-parinfer/issues/21))
+
+More options and configuration settings are planned for future releases. Browse
+the [issues] for an idea of future features. Create a new issue if you can think
+of a useful feature :)
 
 ## Plugin Development Setup
 

--- a/styles/atom-parinfer.less
+++ b/styles/atom-parinfer.less
@@ -16,21 +16,8 @@
   color: @text-color-error;
 }
 
-// NOTE: this is not ready yet, but wanted to save it for future reference
-//       https://github.com/oakmac/atom-parinfer/issues/26
-//
-// @endParenOpacity: 0.5;
-//
-// atom-text-editor::shadow {
-//   span.punctuation.section.map.end.clojure {
-//     opacity: @endParenOpacity;
-//   }
-//
-//   span.punctuation.section.set.end.clojure {
-//     opacity: @endParenOpacity;
-//   }
-//
-//   span.punctuation.section.expression.end.clojure {
-//     opacity: @endParenOpacity;
-//   }
-// }
+atom-text-editor::shadow {
+  span.punctuation.section.end.trailing.clojure {
+    opacity: 0.4;
+  }
+}


### PR DESCRIPTION
This should close https://github.com/oakmac/atom-parinfer/issues/26

Check out the individual commits for details. Summary:

- I set the default opacity to `0.4`.
- I added some instructions to readme since it turns out [language-clojure can't be auto-updated](https://github.com/atom/language-clojure/issues/44#issuecomment-223832391)
- I also merged the duplicate "Future Features" sections in the readme.