### PR TITLE
Fix command name formatting in Command Palette

### DIFF
--- a/keymaps/atom-parinfer.json
+++ b/keymaps/atom-parinfer.json
@@ -1,14 +1,14 @@
 {
   ".platform-linux atom-workspace": {
-    "ctrl-(": "parinfer:toggleMode",
+    "ctrl-(": "parinfer:toggle-mode",
     "ctrl-)": "parinfer:disable"
   },
   ".platform-win32 atom-workspace": {
-    "ctrl-(": "parinfer:toggleMode",
+    "ctrl-(": "parinfer:toggle-mode",
     "ctrl-)": "parinfer:disable"
   },
   ".platform-darwin atom-workspace": {
-    "cmd-(": "parinfer:toggleMode",
+    "cmd-(": "parinfer:toggle-mode",
     "cmd-)": "parinfer:disable"
   }
 }

--- a/lib/atom-parinfer.js
+++ b/lib/atom-parinfer.js
@@ -24083,7 +24083,7 @@ atom_parinfer.core.activate = function(a) {
   atom_parinfer.core.load_file_extensions_BANG_.call(null);
   atom.workspace.observeTextEditors(atom_parinfer.core.hello_editor);
   atom.workspace.onDidChangeActivePaneItem(atom_parinfer.core.pane_changed);
-  atom.commands.add("atom-workspace", {"parinfer:editFileExtensions":atom_parinfer.core.edit_file_extensions_BANG_, "parinfer:disable":atom_parinfer.core.disable_BANG_, "parinfer:toggleMode":atom_parinfer.core.toggle_mode_BANG_});
+  atom.commands.add("atom-workspace", {"parinfer:edit-file-extensions":atom_parinfer.core.edit_file_extensions_BANG_, "parinfer:disable":atom_parinfer.core.disable_BANG_, "parinfer:toggle-mode":atom_parinfer.core.toggle_mode_BANG_});
   setTimeout(atom_parinfer.core.pane_changed, 100);
   setTimeout(atom_parinfer.core.pane_changed, 500);
   setTimeout(atom_parinfer.core.pane_changed, 1E3);

--- a/menus/atom-parinfer.json
+++ b/menus/atom-parinfer.json
@@ -8,11 +8,11 @@
           "submenu": [
             {
               "label": "Edit File Extensions",
-              "command": "parinfer:editFileExtensions"
+              "command": "parinfer:edit-file-extensions"
             },
             {
               "label": "Toggle Mode",
-              "command": "parinfer:toggleMode"
+              "command": "parinfer:toggle-mode"
             },
             {
               "label": "Disable",

--- a/src-cljs/atom_parinfer/core.cljs
+++ b/src-cljs/atom_parinfer/core.cljs
@@ -485,9 +485,9 @@
 
   ;; add package events
   (js/atom.commands.add "atom-workspace"
-    (js-obj "parinfer:editFileExtensions" edit-file-extensions!
+    (js-obj "parinfer:edit-file-extensions" edit-file-extensions!
             "parinfer:disable" disable!
-            "parinfer:toggleMode" toggle-mode!))
+            "parinfer:toggle-mode" toggle-mode!))
 
   ;; Sometimes the editor events can all load before Atom catches up with the DOM
   ;; resulting in an initial empty status bar.


### PR DESCRIPTION
The “Toggle Mode” and “Edit File Extensions” commands were always correctly formatted in the package menu (Packages > Parinfer). But when searching for “Parinfer” in the Command Palette, those commands were named “ToggleMode” and “EditFileExtensions” instead.

I learned the fix from [Atom’s `CommandRegistry` docs](https://atom.io/docs/api/v1.9.8/CommandRegistry):

> If either part consists of multiple words, these must be separated by hyphens. E.g. `awesome-package:turn-it-up-to-eleven`. All words should be lowercased.