### PR TITLE
Make `js-log` and `log` variadiac

### DIFF
--- a/lib/atom-parinfer.js
+++ b/lib/atom-parinfer.js
@@ -23470,10 +23470,40 @@ goog.dom.DomHelper.prototype.getAncestorByClass = goog.dom.getAncestorByClass;
 goog.dom.DomHelper.prototype.getAncestor = goog.dom.getAncestor;
 var atom_parinfer = {util:{}};
 atom_parinfer.util.js_log = function(a) {
-  return console.log(a);
+  for (var b = [], c = arguments.length, d = 0;;) {
+    if (d < c) {
+      b.push(arguments[d]), d += 1;
+    } else {
+      break;
+    }
+  }
+  b = 0 < b.length ? new cljs.core.IndexedSeq(b.slice(0), 0, null) : null;
+  return atom_parinfer.util.js_log.cljs$core$IFn$_invoke$arity$variadic(b);
+};
+atom_parinfer.util.js_log.cljs$core$IFn$_invoke$arity$variadic = function(a) {
+  return console.log.apply(console, cljs.core.to_array.call(null, a));
+};
+atom_parinfer.util.js_log.cljs$lang$maxFixedArity = 0;
+atom_parinfer.util.js_log.cljs$lang$applyTo = function(a) {
+  return atom_parinfer.util.js_log.cljs$core$IFn$_invoke$arity$variadic(cljs.core.seq.call(null, a));
 };
 atom_parinfer.util.log = function(a) {
-  return atom_parinfer.util.js_log.call(null, cljs.core.pr_str.call(null, a));
+  for (var b = [], c = arguments.length, d = 0;;) {
+    if (d < c) {
+      b.push(arguments[d]), d += 1;
+    } else {
+      break;
+    }
+  }
+  b = 0 < b.length ? new cljs.core.IndexedSeq(b.slice(0), 0, null) : null;
+  return atom_parinfer.util.log.cljs$core$IFn$_invoke$arity$variadic(b);
+};
+atom_parinfer.util.log.cljs$core$IFn$_invoke$arity$variadic = function(a) {
+  return atom_parinfer.util.js_log.call(null, cljs.core.apply.call(null, cljs.core.pr_str, a));
+};
+atom_parinfer.util.log.cljs$lang$maxFixedArity = 0;
+atom_parinfer.util.log.cljs$lang$applyTo = function(a) {
+  return atom_parinfer.util.log.cljs$core$IFn$_invoke$arity$variadic(cljs.core.seq.call(null, a));
 };
 atom_parinfer.util.log_atom_changes = function(a, b, c, d) {
   atom_parinfer.util.log.call(null, c);

--- a/src-cljs/atom_parinfer/util.cljs
+++ b/src-cljs/atom_parinfer/util.cljs
@@ -7,14 +7,14 @@
 ;;------------------------------------------------------------------------------
 
 (defn js-log
-  "Logs a JavaScript thing."
-  [js-thing]
-  (js/console.log js-thing))
+  "Logs JavaScript things."
+  [& js-things]
+  (.apply js/console.log js/console (to-array js-things)))
 
 (defn log
-  "Logs a Clojure thing."
-  [clj-thing]
-  (js-log (pr-str clj-thing)))
+  "Logs Clojure things."
+  [& clj-things]
+  (js-log (apply pr-str clj-things)))
 
 (defn log-atom-changes [atm kwd old-value new-value]
   (log old-value)


### PR DESCRIPTION
Now if you want to log multiple items on one line, you won’t have to concatenate them together with `str` first (which would disable the console’s interactive browser feature for complex objects).

The code for `js-log` is based on [this Stack Overflow answer](http://stackoverflow.com/a/35376881/578288). The simple code `(apply js/console.log js-things)` didn’t work, because it seems ClojureScript’s `apply` can’t work with JavaScript functions whose code uses `this`.
