### PR TITLE
[WIP] Use Atom’s Config API instead of dotfiles in the home directory

### DIFF
--- a/lib/atom-parinfer.js
+++ b/lib/atom-parinfer.js
@@ -24078,21 +24078,26 @@ atom_parinfer.core.toggle_mode_BANG_ = function() {
   return cljs.core.truth_(b) ? (cljs.core._EQ_.call(null, b, new cljs.core.Keyword(null, "indent-mode", "indent-mode", 1737814542)) ? cljs.core.swap_BANG_.call(null, atom_parinfer.core.editor_states, cljs.core.assoc, a, new cljs.core.Keyword(null, "paren-mode", "paren-mode", -2068924645)) : cljs.core.swap_BANG_.call(null, atom_parinfer.core.editor_states, cljs.core.assoc, a, new cljs.core.Keyword(null, "indent-mode", "indent-mode", 1737814542)), atom_parinfer.core.debounced_apply_parinfer.call(null)) : 
   null;
 };
+atom_parinfer.core.log_atom_config_BANG_ = function() {
+  atom_parinfer.util.js_log.call(null, atom.config.get("Parinfer.fileExtensions"));
+  atom_parinfer.util.js_log.call(null, atom.config.get("Parinfer.previewCursorScope"));
+  return atom_parinfer.util.js_log.call(null, atom.config.get("Parinfer.showFileOpenWarningDialog"));
+};
 atom_parinfer.core.activate = function(a) {
   atom_parinfer.util.js_log.call(null, [cljs.core.str("atom-parinfer v"), cljs.core.str(atom_parinfer.core.version), cljs.core.str(" activated")].join(""));
   atom_parinfer.core.load_file_extensions_BANG_.call(null);
   atom.workspace.observeTextEditors(atom_parinfer.core.hello_editor);
   atom.workspace.onDidChangeActivePaneItem(atom_parinfer.core.pane_changed);
-  atom.commands.add("atom-workspace", {"parinfer:edit-file-extensions":atom_parinfer.core.edit_file_extensions_BANG_, "parinfer:disable":atom_parinfer.core.disable_BANG_, "parinfer:toggle-mode":atom_parinfer.core.toggle_mode_BANG_});
+  atom.commands.add("atom-workspace", {"parinfer:edit-file-extensions":atom_parinfer.core.edit_file_extensions_BANG_, "parinfer:disable":atom_parinfer.core.disable_BANG_, "parinfer:toggle-mode":atom_parinfer.core.toggle_mode_BANG_, "parinfer:log-atom-config":atom_parinfer.core.log_atom_config_BANG_});
   setTimeout(atom_parinfer.core.pane_changed, 100);
   setTimeout(atom_parinfer.core.pane_changed, 500);
   setTimeout(atom_parinfer.core.pane_changed, 1E3);
   setTimeout(atom_parinfer.core.pane_changed, 2E3);
   return setTimeout(atom_parinfer.core.pane_changed, 5E3);
 };
-module.exports = function() {
-  return {activate:atom_parinfer.core.activate, deactivate:atom_parinfer.util.always_nil, serialize:atom_parinfer.util.always_nil};
-}();
+module.exports = cljs.core.clj__GT_js.call(null, new cljs.core.PersistentArrayMap(null, 4, ["activate", atom_parinfer.core.activate, "deactivate", atom_parinfer.util.always_nil, "serialize", atom_parinfer.util.always_nil, "config", new cljs.core.PersistentArrayMap(null, 3, ["fileExtensions", new cljs.core.PersistentArrayMap(null, 5, ["order", 1, "title", "File Extensions to Enable For", "type", "array", "default", new cljs.core.PersistentVector(null, 2, 5, cljs.core.PersistentVector.EMPTY_NODE, [".clj", 
+".cljs"], null), "items", new cljs.core.PersistentArrayMap(null, 1, ["type", "string"], null)], null), "previewCursorScope", new cljs.core.PersistentArrayMap(null, 4, ["order", 2, "description", "When the cursor is on an empty line, show close-brackets after the cursor, as if you had already typed a character.", "type", "boolean", "default", !1], null), "showFileOpenWarningDialog", new cljs.core.PersistentArrayMap(null, 4, ["order", 3, "description", "Show a dialog when opening a file with unbalanced parentheses or poor indentation.", 
+"type", "boolean", "default", !0], null)], null)], null));
 cljs.core._STAR_main_cli_fn_STAR_ = atom_parinfer.util.always_nil;
 cljs.nodejs = {};
 cljs.nodejs.require = require;

--- a/src-cljs/atom_parinfer/core.cljs
+++ b/src-cljs/atom_parinfer/core.cljs
@@ -471,6 +471,11 @@
       ;; run parinfer in their new mode
       (debounced-apply-parinfer))))
 
+(defn- log-atom-config! []
+  (js-log (js/atom.config.get "Parinfer.fileExtensions"))
+  (js-log (js/atom.config.get "Parinfer.previewCursorScope"))
+  (js-log (js/atom.config.get "Parinfer.showFileOpenWarningDialog")))
+
 ;;------------------------------------------------------------------------------
 ;; Package-required events
 ;;------------------------------------------------------------------------------
@@ -487,7 +492,8 @@
   (js/atom.commands.add "atom-workspace"
     (js-obj "parinfer:edit-file-extensions" edit-file-extensions!
             "parinfer:disable" disable!
-            "parinfer:toggle-mode" toggle-mode!))
+            "parinfer:toggle-mode" toggle-mode!
+            "parinfer:log-atom-config" log-atom-config!))
 
   ;; Sometimes the editor events can all load before Atom catches up with the DOM
   ;; resulting in an initial empty status bar.
@@ -504,9 +510,26 @@
 ;;------------------------------------------------------------------------------
 
 (set! js/module.exports
-  (js-obj "activate" activate
-          "deactivate" always-nil
-          "serialize" always-nil))
+  (clj->js
+    {"activate" activate
+     "deactivate" always-nil
+     "serialize" always-nil
+     "config"
+     {"fileExtensions" {"order" 1
+                        "title" "File Extensions to Enable For"
+                        "type" "array"
+                        "default" [".clj", ".cljs"]
+                        "items" {"type" "string"}}
+      "previewCursorScope" {"order" 2
+                            "description" "When the cursor is on an empty line, show close-brackets after the cursor, as if you had already typed a character."
+                            "type" "boolean"
+                            "default" false}
+      "showFileOpenWarningDialog" {"order" 3
+                                   "description" "Show a dialog when opening a file with unbalanced parentheses or poor indentation."
+                                   "type" "boolean"
+                                   "default" true}}}))
+
+
 
 ;; noop - needed for :nodejs CLJS build
 (set! *main-cli-fn* always-nil)


### PR DESCRIPTION
# The idea

Atom [allows packages to define their own configuration options](http://flight-manual.atom.io/behind-atom/sections/configuration-api/), and lets users set these options with a GUI within Atom’s Settings window.

I think Parinfer’s three configuration settings, which currently rely on two files `~/.atom-parinfer-config.json` and `~/.parinfer-file-extensions.txt`, should be migrated to use this built-in configuration method. That would declutter users’ home directories, allow easier migration of Atom settings from computer to computer, and allow the user to explore the available configuration options more easily.

In this first commit, I have implemented just the in-Atom UI for the settings, using the [`Config`](https://atom.io/docs/api/v1.9.8/Config) API:

![Parinfer for Atom – demo of new Settings UI](https://cloud.githubusercontent.com/assets/79168/17655927/05bbcff2-6282-11e6-8a88-d7e2aa57a8c5.png)

Note that the comma-separated list of “File Extensions to Enable For” is an `"array"`-type config option, not just a plain string. Atom transparently parses it into an array when you read it.

I also implemented a temporary command “Log Atom Config”, which demonstrates the method for reading these config values: `(js/atom.config.get "Parinfer.fileExtensions")`.
# My questions

Before I migrate more of Parinfer to use Atom’s configuration method, I want to check whether you agree that Parinfer should make this change.

I also want to ask what I should do about backwards-compatibility. It will be easy to change the existing code to not read from files any more, and to read from Atom’s config instead. However, then the subset of users who have already customized these three settings would have to set their preferred values again. It’s only three settings, and not much data within them, but it would be somewhat annoying, especially if the users weren’t notified of the change.

I think the ideal would be that, upon loading after upgrading, Parinfer would detect that you have configuration files in the old locations. Then Parinfer would silently delete those files and import their values into the new configuration system. However, implementing that migration would delay this change. That feature would also hang around and make the Parinfer codebase more complex until the feature could be deleted, perhaps after a year.

Do you think users would consider this new feature a net benefit if it were released without the ability to automatically migrate old configuration? Or do you think that migration should be implemented, too, before this feature is included?

The answer depends on the numbers of these types of users, and how strongly they would feel about getting this feature:
- new users
- existing users without any configuration
- existing users with some configuration
