### PR TITLE
Show Full Keyboard Strokes for Changing Modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ their diffs before a code commit :)
 
 ### Hotkeys and Status Bar
 
-|  Command              | Windows/Linux                | Mac                         |
-|-----------------------|-----------------------------:|-----------------------------|
-| Turn on / Toggle Mode | <kbd>Ctrl</kbd>+<kbd>(</kbd> | <kbd>Cmd</kbd>+<kbd>(</kbd> |
-| Turn off              | <kbd>Ctrl</kbd>+<kbd>)</kbd> | <kbd>Cmd</kbd>+<kbd>)</kbd> |
+|  Command              | Windows/Linux                                 | Mac                                          |
+|-----------------------|----------------------------------------------:|----------------------------------------------|
+| Turn on / Toggle Mode | <kbd>Ctrl</kbd>+<kbd>shift</kbd>+<kbd>(</kbd> | <kbd>Cmd</kbd>+<kbd>shift</kbd>+<kbd>(</kbd> |
+| Turn off              | <kbd>Ctrl</kbd>+<kbd>shift</kbd>+<kbd>)</kbd> | <kbd>Cmd</kbd>+<kbd>shift</kbd>+<kbd>)</kbd> |
 
 The status bar will indicate which mode you are in or show nothing if Parinfer
 is turned off.


### PR DESCRIPTION
Please show the full set of keys instead of an implicit shift. Helpful for first time users which might think Parinfer is not working because they are not pressing the right keys.

I would suggest to do same in the documentation of other editors.

Looking forward to using smart mode. Amazing tool.