### PR TITLE
Update Parinfer to 3.12.0

### DIFF
--- a/node_modules/.yarn-integrity
+++ b/node_modules/.yarn-integrity
@@ -3,13 +3,13 @@
   "linkedModules": [],
   "topLevelPatters": [
     "fs-plus@2.8.1",
-    "parinfer@3.10.0"
+    "parinfer@3.12.0"
   ],
   "lockfileEntries": {
     "async@~0.2.9": "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1",
     "fs-plus@2.8.1": "https://registry.yarnpkg.com/fs-plus/-/fs-plus-2.8.1.tgz#60bcae0d2066f4bb4726f23add525dada80630f6",
     "mkdirp@~0.3.5": "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.5.tgz#de3e5f8961c88c787ee1368df849ac4413eca8d7",
-    "parinfer@3.10.0": "https://registry.yarnpkg.com/parinfer/-/parinfer-3.10.0.tgz#cece8af579878ea885041c39a93f5aca24416152",
+    "parinfer@3.12.0": "https://registry.yarnpkg.com/parinfer/-/parinfer-3.12.0.tgz#6ea16236319717d579275aa9a94ed1197c3cbd62",
     "rimraf@~2.2.2": "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582",
     "underscore-plus@1.x": "https://registry.yarnpkg.com/underscore-plus/-/underscore-plus-1.6.6.tgz#65ecde1bdc441a35d89e650fd70dcf13ae439a7d",
     "underscore@~1.6.0": "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"

--- a/node_modules/parinfer/CHANGES.md
+++ b/node_modules/parinfer/CHANGES.md
@@ -1,3 +1,17 @@
+## 3.12.0
+
+- make Smart Mode work better when inputting multiple changes. See [#181]
+
+[#181]:https://github.com/shaunlebron/parinfer/pull/181
+
+## 3.11.0
+
+- fix: `parenTrails` now include those which may appear at the beginning of a line
+- fix: `parens` now correctly assigns relocated leading close-parens to their paren trail
+- enhancement: smart mode with `forceBalance` off will remove unmatched close-parens in a leading paren trail ( see [#163])
+
+[#163]:https://github.com/shaunlebron/parinfer/issues/163
+
 ## 3.10.0
 
 - add: return `parens` (full paren tree) if `returnParens` is enabled
@@ -7,6 +21,9 @@
   - this was causing bad pasting behavior since a line with extra parens would dedent subsequent lines
 - change: smart mode will allow selected lines to be indented in isolation (by running Indent Mode when `selectionStartLine` is passed in)
   - this helps with correcting pastes without influence indentation around it
+  - thanks to [@SevereOverfl0w](https://github.com/SevereOverfl0w)!
+
+[#147]:https://github.com/shaunlebron/parinfer/issues/147
 
 ## 3.9.0
 

--- a/node_modules/parinfer/package.json
+++ b/node_modules/parinfer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parinfer",
-  "version": "3.10.0",
+  "version": "3.12.0",
   "description": "a simpler way to write Lisp",
   "main": "parinfer.js",
   "scripts": {

--- a/node_modules/parinfer/parinfer.js
+++ b/node_modules/parinfer/parinfer.js
@@ -1,5 +1,5 @@
 //
-// Parinfer 3.10.0
+// Parinfer 3.12.0
 //
 // Copyright 2015-2017 © Shaun Lebron
 // MIT License
@@ -198,6 +198,7 @@ function getInitialResult(text, options, mode, smart) {
     lineNo: -1,                // [integer] - output line number we are on
     ch: "",                    // [string] - character we are processing (can be changed to indicate a replacement)
     x: 0,                      // [integer] - output x position of the current character (ch)
+    indentX: UINT_NULL,        // [integer] - x position of the indentation point if present
 
     parenStack: [],            // We track where we are in the Lisp tree by keeping a stack (array) of open-parens.
                                // Stack elements are objects containing keys {ch, x, lineNo, indentDelta}
@@ -441,12 +442,12 @@ function insertWithinLine(result, lineNo, idx, insert) {
   replaceWithinLine(result, lineNo, idx, idx, insert);
 }
 
-function initLine(result, line) {
+function initLine(result) {
   result.x = 0;
   result.lineNo++;
-  result.lines.push(line);
 
   // reset line-specific state
+  result.indentX = UINT_NULL;
   result.commentX = UINT_NULL;
   result.indentDelta = 0;
   delete result.errorPosCache[ERROR_UNMATCHED_CLOSE_PAREN];
@@ -646,9 +647,14 @@ function onMatchedCloseParen(result) {
 
 function onUnmatchedCloseParen(result) {
   if (result.mode === PAREN_MODE) {
-    throw error(result, ERROR_UNMATCHED_CLOSE_PAREN);
+    var trail = result.parenTrail;
+    var inLeadingParenTrail = trail.lineNo === result.lineNo && trail.startX === result.indentX;
+    var canRemove = result.smart && inLeadingParenTrail;
+    if (!canRemove) {
+      throw error(result, ERROR_UNMATCHED_CLOSE_PAREN);
+    }
   }
-  if (!result.errorPosCache[ERROR_UNMATCHED_CLOSE_PAREN]) {
+  else if (result.mode === INDENT_MODE && !result.errorPosCache[ERROR_UNMATCHED_CLOSE_PAREN]) {
     cacheErrorPos(result, ERROR_UNMATCHED_CLOSE_PAREN);
     var opener = peek(result.parenStack, 0);
     if (opener) {
@@ -859,27 +865,191 @@ function popParenTrail(result) {
   }
 }
 
+// Determine which open-paren (if any) on the parenStack should be considered
+// the direct parent of the current line (given its indentation point).
+// This allows Smart Mode to simulate Paren Mode's structure-preserving
+// behavior by adding its `opener.indentDelta` to the current line's indentation.
+// (care must be taken to prevent redundant indentation correction, detailed below)
 function getParentOpenerIndex(result, indentX) {
   var i;
   for (i=0; i<result.parenStack.length; i++) {
     var opener = peek(result.parenStack, i);
-    var currOutside = (opener.x < indentX);
-    var prevOutside = (opener.x - opener.indentDelta < indentX);
 
-    if (prevOutside) {
-      // If an open-paren WAS outside, its `indentDelta` will be used to KEEP IT
-      // outside, by adjusting the indentation of its child lines.
-      break;
+    var currOutside = (opener.x < indentX);
+
+    var prevIndentX = indentX - result.indentDelta;
+    var prevOutside = (opener.x - opener.indentDelta < prevIndentX);
+
+    var isParent = false;
+
+    if (prevOutside && currOutside) {
+      isParent = true;
     }
-    if (currOutside) {
-      // If an open-paren was JUST pushed outside and its parent open-paren was
-      // not pushed by same amount, new child line(s) will be adopted.
-      // Clear `indentDelta` since it is reserved for previous child lines only.
-      var nextOpener = peek(result.parenStack, i+1);
-      if (!nextOpener || nextOpener.indentDelta !== opener.indentDelta) {
-        opener.indentDelta = 0;
-        break;
+    else if (!prevOutside && !currOutside) {
+      isParent = false;
+    }
+    else if (prevOutside && !currOutside) {
+      // POSSIBLE FRAGMENTATION
+      // (foo    --\
+      //            +--- FRAGMENT `(foo bar)` => `(foo) bar`
+      // bar)    --/
+
+      // 1. PREVENT FRAGMENTATION
+      // ```in
+      //   (foo
+      // ++
+      //   bar
+      // ```
+      // ```out
+      //   (foo
+      //     bar
+      // ```
+      if (result.indentDelta === 0) {
+        isParent = true;
       }
+
+      // 2. ALLOW FRAGMENTATION
+      // ```in
+      // (foo
+      //   bar
+      // --
+      // ```
+      // ```out
+      // (foo)
+      // bar
+      // ```
+      else if (opener.indentDelta === 0) {
+        isParent = false;
+      }
+
+      else {
+        // TODO: identify legitimate cases where both are nonzero
+
+        // allow the fragmentation by default
+        isParent = false;
+
+        // TODO: should we throw to exit instead?  either of:
+        // 1. give up, just `throw error(...)`
+        // 2. fallback to paren mode to preserve structure
+      }
+    }
+    else if (!prevOutside && currOutside) {
+      // POSSIBLE ADOPTION
+      // (foo)   --\
+      //            +--- ADOPT `(foo) bar` => `(foo bar)`
+      //   bar   --/
+
+      var nextOpener = peek(result.parenStack, i+1);
+
+      // 1. DISALLOW ADOPTION
+      // ```in
+      //   (foo
+      // --
+      //     (bar)
+      // --
+      //     baz)
+      // ```
+      // ```out
+      // (foo
+      //   (bar)
+      //   baz)
+      // ```
+      // OR
+      // ```in
+      //   (foo
+      // --
+      //     (bar)
+      // -
+      //     baz)
+      // ```
+      // ```out
+      // (foo
+      //  (bar)
+      //  baz)
+      // ```
+      if (nextOpener && nextOpener.indentDelta <= opener.indentDelta) {
+        // we can only disallow adoption if nextOpener.indentDelta will actually
+        // prevent the indentX from being in the opener's threshold.
+        if (indentX + nextOpener.indentDelta > opener.x) {
+          isParent = true;
+        }
+        else {
+          isParent = false;
+        }
+      }
+
+      // 2. ALLOW ADOPTION
+      // ```in
+      // (foo
+      //     (bar)
+      // --
+      //     baz)
+      // ```
+      // ```out
+      // (foo
+      //   (bar
+      //     baz))
+      // ```
+      // OR
+      // ```in
+      //   (foo
+      // -
+      //     (bar)
+      // --
+      //     baz)
+      // ```
+      // ```out
+      //  (foo
+      //   (bar)
+      //    baz)
+      // ```
+      else if (nextOpener && nextOpener.indentDelta > opener.indentDelta) {
+        isParent = true;
+      }
+
+      // 3. ALLOW ADOPTION
+      // ```in
+      //   (foo)
+      // --
+      //   bar
+      // ```
+      // ```out
+      // (foo
+      //   bar)
+      // ```
+      // OR
+      // ```in
+      // (foo)
+      //   bar
+      // ++
+      // ```
+      // ```out
+      // (foo
+      //   bar
+      // ```
+      // OR
+      // ```in
+      //  (foo)
+      // +
+      //   bar
+      // ++
+      // ```
+      // ```out
+      //  (foo
+      //   bar)
+      // ```
+      else if (result.indentDelta > opener.indentDelta) {
+        isParent = true;
+      }
+
+      if (isParent) { // if new parent
+        // Clear `indentDelta` since it is reserved for previous child lines only.
+        opener.indentDelta = 0;
+      }
+    }
+
+    if (isParent) {
+      break;
     }
   }
   return i;
@@ -1006,6 +1176,10 @@ function updateRememberedParenTrail(result) {
   }
   else {
     trail.endX = result.parenTrail.endX;
+    if (result.returnParens) {
+      var opener = result.parenTrail.openers[result.parenTrail.openers.length-1];
+      opener.closer.trail = trail;
+    }
   }
 }
 
@@ -1036,6 +1210,7 @@ function addIndent(result, delta) {
   var indentStr = repeatString(BLANK_SPACE, newIndent);
   replaceWithinLine(result, result.lineNo, 0, origIndent, indentStr);
   result.x = newIndent;
+  result.indentX = newIndent;
   result.indentDelta += delta;
 }
 
@@ -1068,6 +1243,7 @@ function correctIndent(result) {
 }
 
 function onIndent(result) {
+  result.indentX = result.x;
   result.trackingIndent = false;
 
   if (result.quoteDanger) {
@@ -1075,6 +1251,7 @@ function onIndent(result) {
   }
 
   if (result.mode === INDENT_MODE) {
+
     correctParenTrail(result, result.x);
 
     var opener = peek(result.parenStack, 0);
@@ -1108,9 +1285,15 @@ function onLeadingCloseParen(result) {
   }
   if (result.mode === PAREN_MODE) {
     if (!isValidCloseParen(result.parenStack, result.ch)) {
-      throw error(result, ERROR_UNMATCHED_CLOSE_PAREN);
+      if (result.smart) {
+        result.skipChar = true;
+      }
+      else {
+        throw error(result, ERROR_UNMATCHED_CLOSE_PAREN);
+      }
     }
-    if (isCursorLeftOf(result.cursorX, result.cursorLine, result.x, result.lineNo)) {
+    else if (isCursorLeftOf(result.cursorX, result.cursorLine, result.x, result.lineNo)) {
+      resetParenTrail(result, result.lineNo, result.x);
       onIndent(result);
     }
     else {
@@ -1120,7 +1303,7 @@ function onLeadingCloseParen(result) {
   }
 }
 
-function shiftCommentLine(result) {
+function onCommentLine(result) {
   var parenTrailLength = result.parenTrail.openers.length;
 
   // restore the openers matching the previous paren trail
@@ -1131,11 +1314,14 @@ function shiftCommentLine(result) {
     }
   }
 
-  // shift the comment line based on the parent open paren
   var i = getParentOpenerIndex(result, result.x);
   var opener = peek(result.parenStack, i);
-  if (opener && shouldAddOpenerIndent(result, opener)) {
-    addIndent(result, opener.indentDelta);
+  if (opener) {
+    // shift the comment line based on the parent open paren
+    if (shouldAddOpenerIndent(result, opener)) {
+      addIndent(result, opener.indentDelta);
+    }
+    // TODO: store some information here if we need to place close-parens after comment lines
   }
 
   // repop the openers matching the previous paren trail
@@ -1152,7 +1338,7 @@ function checkIndent(result) {
   }
   else if (result.ch === SEMICOLON) {
     // comments don't count as indentation points
-    shiftCommentLine(result);
+    onCommentLine(result);
     result.trackingIndent = false;
   }
   else if (result.ch !== NEWLINE &&
@@ -1231,7 +1417,8 @@ function processChar(result, ch) {
 }
 
 function processLine(result, lineNo) {
-  initLine(result, result.inputLines[lineNo]);
+  initLine(result);
+  result.lines.push(result.inputLines[lineNo]);
 
   setTabStops(result);
 
@@ -1262,7 +1449,7 @@ function finalizeResult(result) {
     }
   }
   if (result.mode === INDENT_MODE) {
-    result.x = 0;
+    initLine(result);
     onIndent(result);
   }
   result.success = true;
@@ -1358,7 +1545,7 @@ function smartMode(text, options) {
 }
 
 var API = {
-  version: "3.10.0",
+  version: "3.12.0",
   indentMode: indentMode,
   parenMode: parenMode,
   smartMode: smartMode

--- a/node_modules/parinfer/test.js
+++ b/node_modules/parinfer/test.js
@@ -1,5 +1,5 @@
 //
-// Parinfer Test 3.10.0
+// Parinfer Test 3.12.0
 //
 // Copyright 2015-2017 © Shaun Lebron
 // MIT License
@@ -190,7 +190,7 @@ function handlePostDiffLine(options, inputLineNo, outputLineNo, outputLines, out
   diff.code = outputLines[diff.codeLineNo];
 }
 
-function parseInput(text, extras) {
+function _parseInput(text, extras) {
   extras = extras || {};
   var options = {};
   if (extras.forceBalance) { options.forceBalance = true; }
@@ -226,6 +226,37 @@ function parseInput(text, extras) {
   return {
     text: outputLines.join("\n"),
     options: options
+  };
+}
+
+function parseInput(texts, extras) {
+  if (!Array.isArray(texts)) {
+    return _parseInput(texts, extras);
+  }
+
+  var changes = [];
+  var resultText;
+  var resultOptions;
+  var i, j;
+  for (i=0; i<texts.length; i++) {
+    var result = _parseInput(texts[i], extras);
+    resultText = result.text;
+    resultOptions = result.options;
+    var newChanges = result.options.changes;
+    if (newChanges) {
+      for (j=0; j<newChanges.length; j++) {
+        changes.push(newChanges[j]);
+      }
+    }
+  }
+
+  if (changes.length > 0) {
+    resultOptions.changes = changes;
+  }
+
+  return {
+    text: resultText,
+    options: resultOptions
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "dependencies": {
     "fs-plus": "2.8.1",
-    "parinfer": "3.10.0"
+    "parinfer": "3.12.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,9 +19,9 @@ mkdirp@~0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.5.tgz#de3e5f8961c88c787ee1368df849ac4413eca8d7"
 
-parinfer@3.10.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/parinfer/-/parinfer-3.10.0.tgz#cece8af579878ea885041c39a93f5aca24416152"
+parinfer@3.12.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/parinfer/-/parinfer-3.12.0.tgz#6ea16236319717d579275aa9a94ed1197c3cbd62"
 
 rimraf@~2.2.2:
   version "2.2.8"


### PR DESCRIPTION
Atom Parinfer is a couple versions behind (3.10.0) the latest (3.12.0).

### 3.11.0

Introduced a fix for the bug shown below—when `forceBalance` is off, and on a new empty line you type `(` and hit <kbd>Backspace</kbd>, you are left with a dangling `)`.

before (broken):
![unbalanced](https://user-images.githubusercontent.com/116838/35780230-028f4cae-099e-11e8-8e3c-6ff8e05da2a1.gif)

after (fixed):
![unbalanced-fix](https://user-images.githubusercontent.com/116838/35780298-d277e0de-099e-11e8-882d-f909b63ec2dc.gif)

### 3.12.0

Introduced bug fixes to stabilize shifting behavior when multiple `changes` are passed to Smart Mode.
With it, I finally extended the test cases to allow reproducing all changes required by the reported bug cases.  This means the temporary _sandbox_ tests have been moved over to proper test cases as planned :).

__Reproducing?__ Most of these bugs were only surfaced for advanced operations performed by Paredit, both in Cursive and here in Atom.  I played with this release and normal operations still work well as expected.

__Still more problems?__ Colin said there are more cases not covered, but he has not produced a reproducible report yet.  Sean also reported some problems at #94, but no reproducible report there either.  But like I said, this is for advanced paredit stuff and won't be seen for basic operations I believe.